### PR TITLE
fix: Update syntax highlighting on posts

### DIFF
--- a/_posts/2013-10-07-pause-javascript-in-the-browser-using-the-debugger-command.md
+++ b/_posts/2013-10-07-pause-javascript-in-the-browser-using-the-debugger-command.md
@@ -8,6 +8,7 @@ Sometimes I want to stop scripts from running in the browser at a specific momen
 
 Just open the browser console and paste this in.
 
-    debugger;
-
+```javascript
+debugger;
+```
 When the time is right, hit 'return' to execute the command and stop the browser. Now you can inspect the DOM and style in the browser to your heart's content.

--- a/_posts/2014-01-19-anchorjs.md
+++ b/_posts/2014-01-19-anchorjs.md
@@ -23,24 +23,26 @@ These "links" point to the specific place on the page that you find them. That's
 
 <put here="" images="">Like I said, I built AnchorJS as a tool to add these links to arbitrary content. It comes with a js and css file that you include on the page, like so:</put>
 
+```html
     <script type="text/javascript" src="anchor.js"></script>
     <link href="anchor.css" rel="stylesheet" />
-
+```
 
 Once it's included, you can use the addAnchors method to add anchors to your page. Here are a few brief usage examples:
 
+```javascript
     /**
      * Example 1
      * Add anchors to all h1&#39;s on the page
      */
-    addAnchors(&#39;h1&#39;);
+    addAnchors('h1');
 
     /**
      * Example 2
      * Adds anchors to elements containing the class &#39;.anchored&#39;
      */
-    addAnchors(&#39;.anchored&#39;);
-
+    addAnchors('.anchored');
+```
 
 And that's pretty much it. You give it a selector, and it does the rest. If you want to [see it in action, here's the Live Demo][5].
 

--- a/_posts/2014-10-19-an-overview-of-javascripts-try-catch.md
+++ b/_posts/2014-10-19-an-overview-of-javascripts-try-catch.md
@@ -12,13 +12,15 @@ Javascript has a pattern called try-catch that can be a bit confusing if you are
 
 Try-catch is a code block, similar to an if conditional. It looks like this:
 
-    try {
-      // put some code here
-    } catch (err) {
-      // put more code here
-    finally {
-      // put more code here
-    }
+```javascript
+try {
+  // put some code here
+} catch (err) {
+  // put more code here
+finally {
+  // put more code here
+}
+```
 
 The purpose of a try-catch block is to handle errors gracefully. And when I say errors, I don't mean bugs or missing semicolons. I mean big, nasty, capital E errors.
 
@@ -34,35 +36,41 @@ The "finally" braces, contains any code that you want to run "no matter what." I
 
 We can test this out by creating our own artificial errors using the 'throw' statement, like so:
 
-    try {
-      throw new Error("My custom error message");
-    } catch (err) {
-      // Print the error message to the console.
-      console.log(err.message);
-    }
+```javascript
+try {
+  throw new Error("My custom error message");
+} catch (err) {
+  // Print the error message to the console.
+  console.log(err.message);
+}
+```
 
 As you can see the "catch" block references a javascript object that we've named \`err\`. This object contains information about the error that was returned, like the error message (stored in \`err.message\`).
 
 Let's make a few changes to our example to bring all these concepts together.
 
-    try {
-      console.log("This is the first 'try' message");
-      throw new Error("My custom error message");
-      console.log("This is the second 'try' message");
-    } catch (e) {
-      console.log("This is the 'catch' message: " + e.message);
-    } finally {
-      console.log("This is the 'finally' message");
-    }
+```javascript
+try {
+  console.log("This is the first 'try' message");
+  throw new Error("My custom error message");
+  console.log("This is the second 'try' message");
+} catch (e) {
+  console.log("This is the 'catch' message: " + e.message);
+} finally {
+  console.log("This is the 'finally' message");
+}
 
-    console.log("This is an additional message, after try-catch-finally");
+console.log("This is an additional message, after try-catch-finally");
+```
 
 Running this code results in the following messages in the console:
 
-    This is the first "try" message
-    This is the "catch" message: My custom error message
-    This is the "finally" message
-    This is an additional message, after try-catch-finally
+```bash
+This is the first "try" message
+This is the "catch" message: My custom error message
+This is the "finally" message
+This is an additional message, after try-catch-finally
+```
 
 As you can see, the second "try" message is skipped because code execution moves to the catch block as soon as our error is encountered. You can also see that our additional message (placed after the try-catch-finally block) runs as well. By "catching" our error, the program can continue running even if it would have otherwise fatally stopped.
 

--- a/_posts/2015-05-17-setting-up-automated-testing-for-a-small-client-side-javascript-project.md
+++ b/_posts/2015-05-17-setting-up-automated-testing-for-a-small-client-side-javascript-project.md
@@ -37,18 +37,22 @@ We can use the [NPM package manager][6] to do several important things for us, l
 
 To start, we'll use NPM to download Jasmine. Create and save a file called `package.json`, that looks like this:
 
-    {
-    "name": "project-name",
-      "description": "My Project&#39;s Description",
-      "version": "0.0.1",
-      "devDependencies": {
-        "jasmine-core": "*"
-      }
-    }
+```json
+{
+"name": "project-name",
+  "description": "My Project&#39;s Description",
+  "version": "0.0.1",
+  "devDependencies": {
+    "jasmine-core": "*"
+  }
+}
+```
 
 Then install the modules referenced by `package.json`:
 
-    npm install
+```bash
+npm install
+```
 
 This installs jasmine-core into a newly created directory in your project called `node_modules`. You'll want to [.gitignore][8] this directory.
 
@@ -56,46 +60,52 @@ This installs jasmine-core into a newly created directory in your project called
 
 Now we're going to set up minimum viable Jasmine testing. I like to keep all my testing stuff in a `test` folder that we can start out looking like this:
 
-    myproject
-      |&nbsp;
-      |--test
-          |-- mySpec.js&nbsp; <----- We&#39;ll write our tests here
-          |-- SpecRunner.html <--- We&#39;ll Run our tests here
+```bash
+myproject
+  |&nbsp;
+  |--test
+      |-- mySpec.js&nbsp; <----- We&#39;ll write our tests here
+      |-- SpecRunner.html <--- We&#39;ll Run our tests here
+```
 
 In mySpec.js, just put a Hello World jasmine test in there, like this one found in Jasmine's Documentation:
 
-    describe("A suite", function() {
-      it("contains spec with an expectation", function() {
-        expect(true).toBe(true);
-      });
-    });
+```javascript
+describe("A suite", function() {
+  it("contains spec with an expectation", function() {
+    expect(true).toBe(true);
+  });
+});
+```
 
 Then, in `SpecRunner.html` (we could name it anything, but this is the name used in some Jasmine packages), we just make a basic html document that links in Jasmine's core files via script tags (as [mentioned in their README][9]).
 
  [9]: https://github.com/jasmine/jasmine#installation
 
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        <meta charset="UTF-8" />
-        <title>Document</title>
-    
-        <link rel="shortcut icon" type="image/png" href="../node_modules/jasmine-core/lib/jasmine-core/jasmine_favicon.png">
-        <link rel="stylesheet" href="../node_modules/jasmine-core/lib/jasmine-core/jasmine.css">
-    
-        <script src="../node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
-        <script src="../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
-        <script src="../node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
-    
-        <!-- include the library you want to test here... -->
-        <script src="../anchor.js"></script>
-    
-        <!-- include your test files here... -->
-        <script src="mySpec.js"></script>
-    </head>
-    <body>
-    </body>
-    </html>
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+      <meta charset="UTF-8" />
+      <title>Document</title>
+
+      <link rel="shortcut icon" type="image/png" href="../node_modules/jasmine-core/lib/jasmine-core/jasmine_favicon.png">
+      <link rel="stylesheet" href="../node_modules/jasmine-core/lib/jasmine-core/jasmine.css">
+
+      <script src="../node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
+      <script src="../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
+      <script src="../node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
+
+      <!-- include the library you want to test here... -->
+      <script src="../anchor.js"></script>
+
+      <!-- include your test files here... -->
+      <script src="mySpec.js"></script>
+  </head>
+  <body>
+  </body>
+</html>
+```
 
 Now you should be able to open `SpecRunner.html` in any browser, and the act of loading the page will run the tests in `mySpec.js`, and display the results. This is sufficient setup for you to read through Jasmine's docs and write tests for features in your library. One note: You could add html in the body tag to test against, but since we'll be automating this process, it's better to dynamically create and delete markup in Jasmine's `beforeEach` and `afterEach` functions. If your library works with the DOM a lot, you may want to look into a tool like [jasmine-fixture][10].
 
@@ -111,9 +121,11 @@ To automate tests, we need to be able to execute a command that runs our tests a
 
  [12]: http://phantomjs.org
 
-    # We install it globally because thats what we do with browsers.
-    # If you don&#39;t have homebrew installed, then see http://phantomjs.org/download.html. Otherwise:
-    brew install phantomjs
+```bash
+# We install it globally because thats what we do with browsers.
+# If you don’t have homebrew installed, then see http://phantomjs.org/download.html. Otherwise:
+brew install phantomjs
+```
 
 Now we need a Test Runner... basically a command-line version of that `SpecRunner.html` file that will load the right files, run the tests, and report back the results. There are a few options out there. If you are already using grunt or gulp, then check out the integrations for those tools. Otherwise, we can save some complexity and go with a dedicated test runner like [Karma][13] (again, I'll leave out the comparisons here, but it suffices to say that Karma is modern, popular, robust, and actively maintained).
 
@@ -121,8 +133,10 @@ Now we need a Test Runner... basically a command-line version of that `SpecRunne
 
 We can bring in Karma with npm:
 
-    # This will add the modules to your package.json and install them.
-    npm install --save-dev karma karma-cli karma-jasmine karma-phantomjs-launcher
+```bash
+# This will add the modules to your package.json and install them.
+npm install --save-dev karma karma-cli karma-jasmine karma-phantomjs-launcher
+```
 
 Note: Karma is highly decoupled, which is why we are downloading several small packages instead of a massive one. This architecture allows it to interface with many possible environments, browsers, and frameworks.
 
@@ -132,11 +146,13 @@ Karma setup is easy, just browse to our tests folder in your terminal and run [`
 
 Finally, we just need to set up a simple "scripts" command in `package.json`.
 
-    "version": "0.0.1",
-    "scripts": {
-        "test": "karma start test/karma.conf.js --single-run"
-    },
-    "devDependencies": {
+```json
+"version": "0.0.1",
+"scripts": {
+    "test": "karma start test/karma.conf.js --single-run"
+},
+"devDependencies": {
+```
 
 <small>Note: this is the last addition to <code>package.json</code>. I've <a href="https://gist.github.com/bryanbraun/4a955cc30c394f137b0d">saved the completed file as a gist</a> for reference.</small>
 
@@ -153,9 +169,11 @@ Now that we have automated tests, the final step is to connect it to [Travis CI]
  [15]: https://travis-ci.org/
  [16]: http://docs.travis-ci.com/user/languages/javascript-with-nodejs/
 
-    language: node_js
-    node_js:
-     - "stable"
+```yaml
+language: node_js
+node_js:
+ - "stable"
+```
 
 Finally commit your changes and push your project, with it's new `test` folder, `package.json` and `.travis.yml` files, up to Github. With some luck, Travis CI will see the code on your `master` branch and run the tests automatically (if not, you can trigger them manually through the TravisCI interface). Once you see it running, the final test is to submit a pull request against your `master` branch. You will know you are victorious, when you see this:
 


### PR DESCRIPTION
This addresses issue #3 

However, I had an issue with the following post: https://www.bryanbraun.com/2014/11/27/every-possible-way-to-define-a-javascript-function/

This has all the code inside of a `<table />` and would require manually setting up the highlighting, from what I can tell. However, I think some of this can be worked around by tweaking your Markdown settings in the `_config.yaml`. Right now there isn’t anything specifying which Markdown renderer to use, but from what I can tell, Kramdown supports Markdown *inside* HTML tags.

Hope this helps!